### PR TITLE
correctly handling datetime without explicitly stated format

### DIFF
--- a/R/datapkg_read.R
+++ b/R/datapkg_read.R
@@ -100,6 +100,9 @@ make_field <- function(name = "", type = "string", description = "", format = NU
   #datapkg prefixes strptime format with 'fmt:'
   if(length(format))
     format <- sub("^fmt:", "", format)
+  else
+    format <- ""
+
   switch(type,
     string = col_character(),
     number = col_number(),


### PR DESCRIPTION
For cases, where the format of a datetime field is not set in datapackage.json e.g 
```
{
  "homepage": "https://data.world/rafaellaureano/cheltenham-s-facebook-group", 
  "name": "rafaellaureano_cheltenham-s-facebook-group", 
  "resources": [
    {
      "format": "csv", 
      "name": "comment", 
      "path": "data/comment.csv", 
      "schema": {
        "fields": [
          {
            "name": "timeStamp", 
            "title": "timeStamp", 
            "type": "datetime"
          }
        ]
      }
    }
  ]
}

```

`datapkg::datapakg_read` will throw this error 
```
Error in read_tokens_(data, tokenizer, col_specs, col_names, locale_,  : 
  expecting a string 
12.
stop(structure(list(message = "expecting a string", call = read_tokens_(data, 
    tokenizer, col_specs, col_names, locale_, n_max, progress), 
    cppstack = NULL), .Names = c("message", "call", "cppstack"
), class = c("Rcpp::not_compatible", "C++Error", "error", "condition" ... 
11.
read_tokens_(data, tokenizer, col_specs, col_names, locale_, 
    n_max, progress) 
10.
read_tokens(ds, tokenizer, spec$cols, names(spec$cols), locale_ = locale, 
    n_max = n_max, progress = progress) 
9.
read_delimited(file, tokenizer, col_names = col_names, col_types = col_types, 
    locale = locale, skip = skip, comment = comment, n_max = n_max, 
    guess_max = guess_max, progress = progress) 
8.
readr::read_delim(col_types = col_types, file = file, delim = delimiter, 
    escape_double = doubleQuote, quote = quoteChar, escape_backslash = identical(escapeChar, 
        "\\"), col_names = header) at datapkg_read.R#126
7.
(function (file, col_types = NULL, delimiter = ",", doubleQuote = TRUE, 
    lineTerminator = "\r\n", quoteChar = "\"", escapeChar = "", 
    skipInitialSpace = TRUE, header = TRUE, caseSensitiveHeader = FALSE) 
{ ... 
6.
do.call(parse_data_file, c(list(file = path, col_types = col_types), 
    dialect)) at datapkg_read.R#95
5.
read_data_package(get_data_path(target, root), dialect = as.list(target$dialect), 
    hash = target$hash, target$schema$fields[[1]]) at datapkg_read.R#56
```

look like passing a NULL format into `col_datetime` is throwing the error. I decided to use `col_datetime(format="")` instead which just mean date times are parse as ISO8601 instead (per https://cran.r-project.org/web/packages/readr/readr.pdf)